### PR TITLE
Add new /v3 path for sops

### DIFF
--- a/index.html
+++ b/index.html
@@ -25,7 +25,7 @@
             <li>go get go.mozilla.org/<a href="/mozlogrus">mozlogrus</a></li>
             <li>go get go.mozilla.org/<a href="/person-api">person-api</a></li>
             <li>go get go.mozilla.org/<a href="/pkcs7">pkcs7</a></li>
-            <li>go get go.mozilla.org/<a href="/sops">sops</a></li>
+            <li>go get go.mozilla.org/<a href="/sops/v3">sops/v3</a></li>
             <li>go get go.mozilla.org/<a href="/userplex">userplex</a></li>
         </ul>
     </p>

--- a/sops/v3/index.html
+++ b/sops/v3/index.html
@@ -1,0 +1,13 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta http-equiv="Content-Type" content="text/html; charset=utf-8"/>
+    <meta name="go-import" content="go.mozilla.org/sops/v3 git https://github.com/mozilla/sops/v3">
+  </head>
+  <body>
+    <h1>go.mozilla.org/sops/v3</h1>
+    <h2>Install with: go get -u go.mozilla.org/sops/v3/cmd/sops</h2>
+    <p>godoc: <a href="https://godoc.org/go.mozilla.org/sops">godoc.org/go.mozilla.org/sops</a></p>
+    <p>source: <a href="https://github.com/mozilla/sops">github.com/mozilla/sops</a></p>
+  </body>
+</html>


### PR DESCRIPTION
`go get go.mozilla.org/sops/v3` and variations should work now, but need to add this (or something similar) to fix it on the `go.mozilla.org` side.

`go get github.com/mozilla/sops/v3` works, except that now there is a `go.mod` file that specifies it as `go.mozilla.org/sops/v3`.
